### PR TITLE
Automatically determine the correct remote script path 

### DIFF
--- a/DataTypes.mw.php
+++ b/DataTypes.mw.php
@@ -50,7 +50,7 @@ Message::registerTextFunction( function() {
 $GLOBALS['wgHooks']['ResourceLoaderTestModules'][] = function ( array &$testModules, \ResourceLoader &$resourceLoader ) {
 	$moduleTemplate = array(
 		'localBasePath' => __DIR__ . '/tests/qunit',
-		'remoteExtPath' => '../vendor/data-values/data-types/tests/qunit',
+		'remoteExtPath' => '..' . substr( __DIR__, strlen( $GLOBALS['IP'] ) ) . '/tests/qunit',
 	);
 
 	$testModules['qunit']['dataTypes.tests'] = $moduleTemplate + array(

--- a/DataTypes.resources.php
+++ b/DataTypes.resources.php
@@ -13,7 +13,7 @@ return call_user_func( function() {
 
 	$moduleTemplate = array(
 		'localBasePath' => __DIR__ . '/resources',
-		'remoteExtPath' => '../vendor/data-values/data-types/resources',
+		'remoteExtPath' => '..' . substr( __DIR__, strlen( $GLOBALS['IP'] ) ) . '/resources',
 	);
 
 	return array(


### PR DESCRIPTION
Just hardcoding it to DataTypes does not work when the extension is installed into another extension, as will for instance happen in the Wikidata build.
