### PR TITLE
Removed DataValues dependency from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,9 +20,7 @@
 		"irc": "irc://irc.freenode.net/wikidata"
 	},
 	"require": {
-		"php": ">=5.3.0",
-		"data-values/data-values": "~0.1",
-		"data-values/interfaces": "~0.1"
+		"php": ">=5.3.0"
 	},
 	"autoload": {
 		"files" : [


### PR DESCRIPTION
Dependency on DataValues is not required anymore as of commit e46a45ed81efc956ebee405419fa22dd7405a6fe.
