### PR TITLE
Remove unused wgDataTypes

### DIFF
--- a/DataTypes.php
+++ b/DataTypes.php
@@ -18,30 +18,6 @@ if ( defined( 'DataTypes_VERSION' ) ) {
 
 define( 'DataTypes_VERSION', '0.2.1' );
 
-$GLOBALS['wgDataTypes'] = array(
-	'commonsMedia' => array(
-		'datavalue' => 'string',
-	),
-	'string' => array(
-		'datavalue' => 'string',
-	),
-	'globe-coordinate' => array(
-		'datavalue' => 'globecoordinate',
-	),
-	'quantity' => array(
-		'datavalue' => 'quantity',
-	),
-	'monolingualtext' => array(
-		'datavalue' => 'monolingualtext',
-	),
-	'multilingualtext' => array(
-		'datavalue' => 'multilingualtext',
-	),
-	'time' => array(
-		'datavalue' => 'time',
-	),
-);
-
 // @codeCoverageIgnoreStart
 if ( defined( 'MEDIAWIKI' ) ) {
 	include __DIR__ . '/DataTypes.mw.php';

--- a/tests/Phpunit/DataTypeFactoryTest.php
+++ b/tests/Phpunit/DataTypeFactoryTest.php
@@ -23,31 +23,11 @@ class DataTypeFactoryTest extends \PHPUnit_Framework_TestCase {
 	 * @return DataTypeFactory
 	 */
 	protected function getInstance() {
-		static $typeSpecs = array(
-			'commonsMedia' => array(
-				'datavalue' => 'string',
-			),
-			'string' => array(
-				'datavalue' => 'string',
-			),
-			'globe-coordinate' => array(
-				'datavalue' => 'globecoordinate',
-			),
-			'quantity' => array(
-				'datavalue' => 'quantity',
-			),
-			'monolingualtext' => array(
-				'datavalue' => 'monolingualtext',
-			),
-			'multilingualtext' => array(
-				'datavalue' => 'multilingualtext',
-			),
-			'time' => array(
-				'datavalue' => 'time',
-			) );
-
 		if ( $this->instance === null ) {
-			$this->instance = new DataTypeFactory( $typeSpecs );
+			$typeBuilders = array(
+				'string' => array( 'datavalue' => 'string' ),
+			);
+			$this->instance = new DataTypeFactory( $typeBuilders );
 		}
 
 		return $this->instance;

--- a/tests/Phpunit/DataTypeTest.php
+++ b/tests/Phpunit/DataTypeTest.php
@@ -17,7 +17,11 @@ class DataTypeTest extends \PHPUnit_Framework_TestCase {
 	 * @return DataType[]
 	 */
 	protected function getInstances() {
-		$factory = new DataTypeFactory( $GLOBALS['wgDataTypes'] );
+		$typeBuilders = array(
+			'string' => array( 'datavalue' => 'string' ),
+		);
+		$factory = new DataTypeFactory( $typeBuilders );
+
 		return $factory->getTypes();
 	}
 


### PR DESCRIPTION
The global is not used anywhere in our code base, as far as I can tell. It conflicts with the list in `WikibaseDataTypeBuilders::getDataTypeBuilders`.

This patch may miss something (like documentation or increasing the version number, maybe). It may be completely wrong (like it really is needed for a reason I don't understand at the moment). Please tell me.
