### PR TITLE
Simplify remoteExtPath regex

### DIFF
--- a/js/resources.php
+++ b/js/resources.php
@@ -10,16 +10,12 @@
  * @codeCoverageIgnoreStart
  */
 return call_user_func( function() {
-	preg_match(
-		'+^.*?' . preg_quote( DIRECTORY_SEPARATOR, '+' ) . '((?:vendor|extensions)' .
-			preg_quote( DIRECTORY_SEPARATOR, '+' ) . '.*)$+',
-		__DIR__,
-		$remoteExtPathParts
-	);
+	preg_match( '+' . preg_quote( DIRECTORY_SEPARATOR ) . '(?:vendor|extensions)'
+		. preg_quote( DIRECTORY_SEPARATOR ) . '.*+', __DIR__, $remoteExtPath );
 
 	$moduleTemplate = array(
 		'localBasePath' => __DIR__,
-		'remoteExtPath' => '..' . DIRECTORY_SEPARATOR . $remoteExtPathParts[1],
+		'remoteExtPath' => '..' . $remoteExtPath[0],
 	);
 
 	return array(


### PR DESCRIPTION
The complexity of this regular expression is just not needed. Just search for the first occurrence of `/vendor/` or `/extensions/` and match everything from there, that's it. Using a regex character (`+`) as delimiter does have the advantage that it must not be repeated when calling `preg_quote`, it's always quoted.
