### PR TITLE
Drop composer update from test bootstrap

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -13,10 +13,8 @@ if ( php_sapi_name() !== 'cli' ) {
 	die( 'Not an entry point' );
 }
 
-$pwd = getcwd();
-chdir( __DIR__ . '/..' );
-passthru( 'composer update' );
-chdir( $pwd );
+error_reporting( E_ALL | E_STRICT );
+ini_set( 'display_errors', 1 );
 
 if ( !is_readable( __DIR__ . '/../vendor/autoload.php' ) ) {
 	die( 'You need to install this package with Composer before you can run the tests' );


### PR DESCRIPTION
We did this in almost all components now. The enforced `composer update` call usually needs much, much more time than the actual tests, hindering CI.