### PR TITLE
Update i18n/nb: tid -> tidspunkt

### DIFF
--- a/i18n/nb.json
+++ b/i18n/nb.json
@@ -15,5 +15,5 @@
     "datatypes-type-unknown": "Uspesifisert",
     "datatypes-type-boolean": "Boolsk verdi",
     "datatypes-type-globe-coordinate": "Geografiske koordinater",
-    "datatypes-type-time": "Tid"
+    "datatypes-type-time": "Tidspunkt"
 }


### PR DESCRIPTION
Since the datatype refers to a point in time (precise or not), this should be a better translation. Originally pointed out at https://www.wikidata.org/wiki/Wikidata:Diskusjon#Bokm.C3.A5lsoversettelser_av_QuantityValue_og_TimeValue . I first updated https://translatewiki.net/w/i.php?title=MediaWiki%3ADatatypes-type-time%2Fnb&type=revision&diff=6097471&oldid=4780919 , but forgot that TranslateWiki is no longer used for this…