### PR TITLE
Simplify DataType and DataTypeFactory

### DIFF
--- a/DataTypes.php
+++ b/DataTypes.php
@@ -16,7 +16,7 @@ if ( defined( 'DataTypes_VERSION' ) ) {
 	return 1;
 }
 
-define( 'DataTypes_VERSION', '0.4.3' );
+define( 'DataTypes_VERSION', '0.5' );
 
 // @codeCoverageIgnoreStart
 if ( defined( 'MEDIAWIKI' ) ) {

--- a/README.md
+++ b/README.md
@@ -23,11 +23,11 @@ the git repository and take care of loading yourself.
 To add this package as a local, per-project dependency to your project, simply add a
 dependency on `data-values/data-types` to your project's `composer.json` file.
 Here is a minimal example of a `composer.json` file that just defines a dependency on
-DataTypes 0.4:
+DataTypes 0.5:
 
     {
         "require": {
-            "data-values/data-types": "~0.4"
+            "data-values/data-types": "~0.5"
         }
     }
 
@@ -50,6 +50,11 @@ DataTypes has been written by the Wikidata team at [Wikimedia Germany](https://w
 for the [Wikidata project](https://wikidata.org/).
 
 ## Release notes
+
+### 0.5 (2015-08-06)
+
+* Drop support for ValueValidators in DataTypes
+* Simplified DataTypeFactory
 
 ### 0.4.3 (2015-06-18)
 

--- a/composer.json
+++ b/composer.json
@@ -14,13 +14,20 @@
 			"email": "jeroendedauw@gmail.com",
 			"homepage": "http://jeroendedauw.com",
 			"role": "Developer"
+		},
+		{
+			"name": "Daniel Kinzler"
 		}
 	],
 	"support": {
 		"irc": "irc://irc.freenode.net/wikidata"
 	},
 	"require": {
-		"php": ">=5.3.0"
+		"php": ">=5.3.0",
+		"wikimedia/assert": "~0.2.2"
+	},
+	"require-dev": {
+		"phpunit/phpunit": "3.7.37"
 	},
 	"autoload": {
 		"files" : [

--- a/src/DataType.php
+++ b/src/DataType.php
@@ -3,7 +3,6 @@
 namespace DataTypes;
 
 use InvalidArgumentException;
-use ValueValidators\ValueValidator;
 
 /**
  * @since 0.1
@@ -32,24 +31,14 @@ class DataType {
 	protected $dataValueType;
 
 	/**
-	 * The ValueValidator objects used by this data type.
-	 *
-	 * @since 0.1
-	 *
-	 * @var ValueValidator[]
-	 */
-	protected $validators;
-
-	/**
-	 * @since 0.1
+	 * @since 0.5
 	 *
 	 * @param string $typeId
 	 * @param string $dataValueType
-	 * @param ValueValidator[] $validators
 	 *
 	 * @throws InvalidArgumentException
 	 */
-	public function __construct( $typeId, $dataValueType, array $validators ) {
+	public function __construct( $typeId, $dataValueType ) {
 		if ( !is_string( $typeId ) ) {
 			throw new InvalidArgumentException( '$typeId must be a string' );
 		}
@@ -60,7 +49,6 @@ class DataType {
 
 		$this->typeId = $typeId;
 		$this->dataValueType = $dataValueType;
-		$this->validators = $validators;
 	}
 
 	/**
@@ -83,17 +71,6 @@ class DataType {
 	 */
 	public function getDataValueType() {
 		return $this->dataValueType;
-	}
-
-	/**
-	 * Returns the ValueValidators that are supported by this data type.
-	 *
-	 * @since 0.1
-	 *
-	 * @return ValueValidator[]
-	 */
-	public function getValidators() {
-		return $this->validators;
 	}
 
 	/**

--- a/tests/Phpunit/DataTypeFactoryTest.php
+++ b/tests/Phpunit/DataTypeFactoryTest.php
@@ -24,10 +24,10 @@ class DataTypeFactoryTest extends \PHPUnit_Framework_TestCase {
 	 */
 	protected function getInstance() {
 		if ( $this->instance === null ) {
-			$typeBuilders = array(
-				'string' => array( 'datavalue' => 'string' ),
+			$types = array(
+				'string' => 'string',
 			);
-			$this->instance = new DataTypeFactory( $typeBuilders );
+			$this->instance = new DataTypeFactory( $types );
 		}
 
 		return $this->instance;
@@ -81,28 +81,9 @@ class DataTypeFactoryTest extends \PHPUnit_Framework_TestCase {
 	public static function provideDataTypeBuilder() {
 		return array(
 			array( // #0
-				'old-school',
-				array( 'datavalue' => 'oldschool' ),
-				'oldschool',
-				'old style spec'
-			),
-			array( // #1
-				'new-school',
-				new DataType( 'new-school', 'newschool', array() ),
-				'newschool',
-				'DataValue object'
-			),
-			array( // #2
-				'new-school',
-				array( '\DataTypes\Tests\Phpunit\DummyType', '__construct' ),
-				'dummy',
-				'constructor'
-			),
-			array( // #3
-				'new-school',
-				array( '\DataTypes\Tests\Phpunit\DummyType', 'newDummy' ),
-				'dummy',
-				'callable'
+				'data-type',
+				array( 'data-type' => 'valuetype' ),
+				'valuetype'
 			),
 		);
 	}
@@ -110,23 +91,13 @@ class DataTypeFactoryTest extends \PHPUnit_Framework_TestCase {
 	/**
 	 * @dataProvider provideDataTypeBuilder
 	 */
-	public function testDataTypeBuilder( $id, $builderSpec, $expected, $message ) {
-		$factory = new DataTypeFactory( array( $id => $builderSpec ) );
+	public function testDataTypeBuilder( $id, $types, $expected ) {
+		$factory = new DataTypeFactory( $types );
 
 		$type = $factory->getType( $id );
 
-		$this->assertEquals( $id, $type->getId(), $message );
-		$this->assertEquals( $expected, $type->getDataValueType(), $message );
+		$this->assertEquals( $id, $type->getId() );
+		$this->assertEquals( $expected, $type->getDataValueType() );
 	}
 
-}
-
-class DummyType extends DataType {
-	public function __construct( $typeId, $dataValueType = 'dummy' ) {
-		parent::__construct( $typeId, $dataValueType, array(), array(), array() );
-	}
-
-	public static function newDummy( $typeId ) {
-		return new DummyType( $typeId );
-	}
 }

--- a/tests/Phpunit/DataTypeTest.php
+++ b/tests/Phpunit/DataTypeTest.php
@@ -17,10 +17,9 @@ class DataTypeTest extends \PHPUnit_Framework_TestCase {
 	 * @return DataType[]
 	 */
 	protected function getInstances() {
-		$typeBuilders = array(
-			'string' => array( 'datavalue' => 'string' ),
-		);
-		$factory = new DataTypeFactory( $typeBuilders );
+		$factory = new DataTypeFactory( array(
+			'string' => 'string',
+		) );
 
 		return $factory->getTypes();
 	}
@@ -49,15 +48,6 @@ class DataTypeTest extends \PHPUnit_Framework_TestCase {
 	 */
 	public function testGetDataValueType( DataType $type ) {
 		$this->assertInternalType( 'string', $type->getDataValueType() );
-	}
-
-	/**
-	 * @dataProvider instanceProvider
-	 * @param DataType $type
-	 */
-	public function testGetValidators( DataType $type ) {
-		$this->assertInternalType( 'array', $type->getValidators() );
-		$this->assertContainsOnlyInstancesOf( 'ValueValidators\ValueValidator', $type->getValidators() );
 	}
 
 	/**


### PR DESCRIPTION
[BREAKING] This removes ValueValidators from DataType, which was unused.
DataType is no a simple pair of data type name and the associated value type id.

DataTypeFactory is accordingly simplified to no longer use callbacks, but instead
just take an array mapping data type names to value type ids.

Needed by https://gerrit.wikimedia.org/r/#/c/228848

This is a breaking change, since it modifies the constructor signature of DataType and DataTypeFactory.