### PR TITLE
Remove barely used dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,8 +23,7 @@
 		"irc": "irc://irc.freenode.net/wikidata"
 	},
 	"require": {
-		"php": ">=5.3.0",
-		"wikimedia/assert": "~0.2.2"
+		"php": ">=5.3.0"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "3.7.37"

--- a/src/DataTypeFactory.php
+++ b/src/DataTypeFactory.php
@@ -3,7 +3,7 @@
 namespace DataTypes;
 
 use OutOfBoundsException;
-use Wikimedia\Assert\Assert;
+use InvalidArgumentException;
 
 /**
  * @licence GNU GPL v2+
@@ -27,9 +27,15 @@ class DataTypeFactory {
 	 * @since 0.5
 	 *
 	 * @param string[] $valueTypes
+	 *
+	 * @throws InvalidArgumentException
 	 */
 	public function __construct( array $valueTypes ) {
-		Assert::parameterElementType( 'string', $valueTypes, '$valueTypes' );
+		foreach ( $valueTypes as $valueType ) {
+			if ( !is_string( $valueType ) ) {
+				throw new InvalidArgumentException( '$valueTypes needs to be an array of string' );
+			}
+		}
 
 		$this->valueTypes = $valueTypes;
 	}


### PR DESCRIPTION
Replacing 3 simple LLOC with 1 less obvious LLOC is not worth pulling
in an additional dependency IMO.

This also fixes the missing @throws tag