### PR TITLE
Rewrite namespace initialization

### DIFF
--- a/js/dataTypes/__namespace.js
+++ b/js/dataTypes/__namespace.js
@@ -1,4 +1,4 @@
 /**
  * @ignore
  */
-this.dataTypes = {};
+var dataTypes = dataTypes || {};


### PR DESCRIPTION
"this" should not be used. Tools complain about this. The new way I'm doing this here is consistent with the other places where we initialize a namespace.