### PR TITLE
Document Message::registerTextFunction parameters

### DIFF
--- a/DataTypes.mw.php
+++ b/DataTypes.mw.php
@@ -34,13 +34,11 @@ $GLOBALS['wgHooks']['UnitTestsList'][] = function( array &$paths ) {
 	return true;
 };
 
-Message::registerTextFunction( function() {
+Message::registerTextFunction( function( $key, $languageCode ) {
 	// @codeCoverageIgnoreStart
-	$args = func_get_args();
-	$key = array_shift( $args );
-	$language = array_shift( $args );
-	$message = new \Message( $key, $args );
-	return $message->inLanguage( $language )->text();
+	$params = array_slice( func_get_args(), 2 );
+	$message = new \Message( $key, $params );
+	return $message->inLanguage( $languageCode )->text();
 	// @codeCoverageIgnoreEnd
 } );
 

--- a/src/DataType.php
+++ b/src/DataType.php
@@ -9,6 +9,7 @@ use InvalidArgumentException;
  *
  * @licence GNU GPL v2+
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ * @author Thiemo Mättig
  */
 class DataType {
 
@@ -78,12 +79,12 @@ class DataType {
 	 *
 	 * @since 0.1
 	 *
-	 * @param string $langCode
+	 * @param string $languageCode
 	 *
-	 * @return string|null
+	 * @return string
 	 */
-	public function getLabel( $langCode ) {
-		return Message::text( 'datatypes-type-' . $this->getId(), $langCode );
+	public function getLabel( $languageCode ) {
+		return Message::text( 'datatypes-type-' . $this->typeId, $languageCode );
 	}
 
 	/**

--- a/src/Message.php
+++ b/src/Message.php
@@ -26,7 +26,15 @@ class Message {
 		self::$textFunction = $textFunction;
 	}
 
-	public static function text() {
+	/**
+	 * @param string $key
+	 * @param string $languageCode
+	 * @param string [$params,...]
+	 *
+	 * @throws Exception
+	 * @return string
+	 */
+	public static function text( $key, $languageCode ) {
 		if ( is_null( self::$textFunction ) ) {
 			throw new Exception( 'No text function set in DataTypes\Message' );
 		} else {


### PR DESCRIPTION
Originally this patch contained three things:
- The two required parameters `$key, $languageCode` of the text function are now properly documented. This is not a breaking change. The documentation always said these two parameters are required.
- ~~Empty strings in the `DataType` constructor are now disallowed~~ (this got moved to #47).
- ~~I rewrote the test completely and made it independent from the factory~~ (this got moved to #49).
