### PR TITLE
Mention "property type" in documentation

### DIFF
--- a/src/DataType.php
+++ b/src/DataType.php
@@ -13,7 +13,7 @@ use InvalidArgumentException;
 class DataType {
 
 	/**
-	 * Identifier for the data type.
+	 * Identifier of this data type (also referred to as "property type").
 	 *
 	 * @since 0.1
 	 *
@@ -33,8 +33,8 @@ class DataType {
 	/**
 	 * @since 0.5
 	 *
-	 * @param string $typeId
-	 * @param string $dataValueType
+	 * @param string $typeId Identifier of this data type (also referred to as "property type").
+	 * @param string $dataValueType Identifier for the type of the DataValue.
 	 *
 	 * @throws InvalidArgumentException
 	 */
@@ -52,7 +52,7 @@ class DataType {
 	}
 
 	/**
-	 * Returns the identifier of this data type.
+	 * Returns the identifier of this data type (also referred to as "property type").
 	 *
 	 * @since 0.1
 	 *
@@ -91,7 +91,7 @@ class DataType {
 	 *
 	 * @since 0.1
 	 *
-	 * @return array
+	 * @return string[]
 	 */
 	public function toArray() {
 		return array(

--- a/src/DataTypeFactory.php
+++ b/src/DataTypeFactory.php
@@ -14,7 +14,7 @@ use OutOfBoundsException;
 class DataTypeFactory {
 
 	/**
-	 * Maps type id to DataType.
+	 * Associative array mapping data type identifiers to DataType objects.
 	 *
 	 * @var DataType[]
 	 */
@@ -28,8 +28,8 @@ class DataTypeFactory {
 	/**
 	 * @since 0.5
 	 *
-	 * @param string[] $valueTypes Associative array mapping data type identifiers to data value
-	 *  type identifiers.
+	 * @param string[] $valueTypes Associative array mapping data type identifiers (also
+	 *  referred to as "property types") to data value type identifiers.
 	 *
 	 * @throws InvalidArgumentException
 	 */
@@ -70,7 +70,7 @@ class DataTypeFactory {
 	}
 
 	/**
-	 * Returns the type identifiers.
+	 * Returns the list of registered data type identifiers (also referred to as "property types").
 	 *
 	 * @since 0.1
 	 *
@@ -86,7 +86,7 @@ class DataTypeFactory {
 	 *
 	 * @since 0.1
 	 *
-	 * @param string $typeId
+	 * @param string $typeId Data type identifier (also referred to as "property type").
 	 *
 	 * @throws OutOfBoundsException if the requested type is not known.
 	 * @return DataType
@@ -106,7 +106,7 @@ class DataTypeFactory {
 
 	/**
 	 * Returns all data types in an associative array with
-	 * the keys being type identifiers pointing to their
+	 * the keys being data type identifiers (also referred to as "property types") pointing to their
 	 * corresponding data type.
 	 *
 	 * @since 0.1


### PR DESCRIPTION
Historically we used the terms "data type" and "data value type", which is incredibly confusing.

Nowadays we try to use the terms "property type" (PT) and "value type" (VT).

But here in the DataTypes component properties are not a known concept. All this component really knows is that a DataType object does have an id. However, I find it very helpful to at least mention "property types".