### PR TITLE
Fix undefined variable when running DataTypesModuleTest

### DIFF
--- a/tests/Modules/DataTypesModuleTest.php
+++ b/tests/Modules/DataTypesModuleTest.php
@@ -17,13 +17,13 @@ class DataTypesModuleTest extends \PHPUnit_Framework_TestCase {
 	 * @return array [instance, resource definition]
 	 */
 	public function provideDataTypesModuleAndResourceDefinition() {
-		$dataTypeFactory = new DataTypeFactory();
+		$dataTypeFactory = new DataTypeFactory( array( 'url' => 'string' ) );
 
 		$validResourceDefinitions = array(
 			array(
 				'datatypesconfigvarname' => 'foo',
 				'datatypefactory' => function() {
-					return new DataTypeFactory();
+					return new DataTypeFactory( array() );
 				}
 			),
 			array(
@@ -58,12 +58,12 @@ class DataTypesModuleTest extends \PHPUnit_Framework_TestCase {
 	 * @return array [invalid resource definition, case description]
 	 */
 	public function provideInvalidResourceDefinition() {
-		$dataTypeFactory = new DataTypeFactory();
+		$dataTypeFactory = new DataTypeFactory( array() );
 
 		$validDefinition = array(
 			'datatypesconfigvarname' => 'foo',
 			'datatypefactory' => function() {
-				return new DataTypeFactory();
+				return new DataTypeFactory( array() );
 			}
 		);
 


### PR DESCRIPTION
An alternative fix could be to make the constructor param optional and default to an empty array, but think it is okay to fix this way.

Bug: T127118