### PR TITLE
Register phpunit tests with MediaWiki

### DIFF
--- a/DataTypes.mw.php
+++ b/DataTypes.mw.php
@@ -27,6 +27,13 @@ $GLOBALS['wgExtensionCredits']['datavalues'][] = array(
 
 $GLOBALS['wgMessagesDirs']['DataTypes'] = __DIR__ . '/i18n';
 
+$GLOBALS['wgHooks']['UnitTestsList'][] = function( array &$paths ) {
+	$paths[] = __DIR__ . '/tests/Modules/';
+	$paths[] = __DIR__ . '/tests/Phpunit/';
+
+	return true;
+};
+
 Message::registerTextFunction( function() {
 	// @codeCoverageIgnoreStart
 	$args = func_get_args();


### PR DESCRIPTION
The resource loader module tests depend on MediaWiki.

Registering the tests will at least allow them to be run when the Wikidata build is tested, for example.