### PR TITLE
Revert "Rewrite namespace initialization"

### DIFF
--- a/js/dataTypes/__namespace.js
+++ b/js/dataTypes/__namespace.js
@@ -1,4 +1,4 @@
 /**
  * @ignore
  */
-var dataTypes = dataTypes || {};
+this.dataTypes = {};


### PR DESCRIPTION
Reverts wmde/DataTypes#44

We need `dataTypes` in window… RL doesn't run modules in the global scope (but `this` still is window).