### PR TITLE
Release 1.1.0

### DIFF
--- a/DataTypes.php
+++ b/DataTypes.php
@@ -14,7 +14,12 @@ if ( defined( 'DATATYPES_VERSION' ) ) {
 	return 1;
 }
 
-define( 'DATATYPES_VERSION', '1.0.0' );
+define( 'DATATYPES_VERSION', '1.1.0' );
+
+/**
+ * @deprecated
+ */
+define( 'DataTypes_VERSION', DATATYPES_VERSION );
 
 if ( defined( 'MEDIAWIKI' ) ) {
 	include __DIR__ . '/DataTypes.mw.php';

--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ for the [Wikidata project](https://wikidata.org/).
 
 ## Release notes
 
+### 1.1.0 (dev)
+* Renamed `DataTypes_VERSION` constant to `DATATYPES_VERSION`, leaving a deprecated alias.
+* Updated internationalizations.
+
 ### 1.0.0 (2016-12-29)
 * `DataType` and `DataTypeFactory` do not accept empty strings any more.
 * Removed `DataType::getLabel` along with the `DataTypes\Message` class.

--- a/build/travis/script.sh
+++ b/build/travis/script.sh
@@ -10,5 +10,5 @@ cd -
 
 fi
 
-composer ci
+composer test
 ./node_modules/.bin/eslint .

--- a/composer.json
+++ b/composer.json
@@ -39,14 +39,8 @@
 	},
 	"scripts": {
 		"test": [
+			"phpcs -p -s",
 			"phpunit"
-		],
-		"phpcs": [
-			"vendor/bin/phpcs -sp"
-		],
-		"ci": [
-			"@test",
-			"@phpcs"
 		]
 	}
 }

--- a/js/dataTypes/DataType.js
+++ b/js/dataTypes/DataType.js
@@ -30,23 +30,26 @@
 		this._dataValueType = dataValueType;
 	};
 
+	/**
+	 * @class dataTypes.DataType
+	 */
 	$.extend( SELF.prototype, {
 		/**
-		 * DataType identifier.
+		 * Data type (a.k.a. property type) identifier.
 		 * @property {string}
 		 * @private
 		 */
 		_id: null,
 
 		/**
-		 * DataValue identifier.
+		 * Identifier of the data value type internally used by this data type.
 		 * @property {string}
 		 * @private
 		 */
 		_dataValueType: null,
 
 		/**
-		 * Returns the data type's identifier.
+		 * Returns the data type (a.k.a. property type) identifier.
 		 *
 		 * @return {string}
 		 */
@@ -55,7 +58,7 @@
 		},
 
 		/**
-		 * Returns the DataValue used by this data type.
+		 * Returns the identifier of the data value type internally used by this data type.
 		 *
 		 * @return {string}
 		 */

--- a/js/dataTypes/DataTypeStore.js
+++ b/js/dataTypes/DataTypeStore.js
@@ -2,7 +2,6 @@
 	'use strict';
 
 	/**
-	 * DataType store.
 	 * @class dataTypes.DataTypeStore
 	 * @since 0.2
 	 * @license GPL-2.0+
@@ -14,6 +13,9 @@
 		this._dataTypes = {};
 	};
 
+	/**
+	 * @class dataTypes.DataTypeStore
+	 */
 	$.extend( SELF.prototype, {
 		/**
 		 * Data type definitions.

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <ruleset name="DataValuesDataTypes">
-	<rule ref="vendor/wikibase/wikibase-codesniffer/Wikibase" />
+	<rule ref="./vendor/wikibase/wikibase-codesniffer/Wikibase" />
 
 	<file>.</file>
 </ruleset>


### PR DESCRIPTION
This change simplifies a few details just recently introduced with #69.

Note that I must reintroduce the old constant. Otherwise this would be a 2.0.0 breaking release, which I think is not necessary and not justified by the otherwise trivial changes done.

I suggest to not wait any longer with a release so we can have the new translations on the live site.