### PR TITLE
Make Travis properly report CI errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,9 @@ before_script:
   - composer install --prefer-source
   - npm install eslint eslint-config-wikimedia
 
-script: bash ./build/travis/script.sh
+script:
+  - composer test
+  - bash ./build/travis/script.sh
 
 notifications:
   email:

--- a/DataTypes.php
+++ b/DataTypes.php
@@ -9,17 +9,12 @@
 
 namespace DataTypes;
 
-if ( defined( 'DATATYPES_VERSION' ) ) {
+if ( defined( 'DataTypes_VERSION' ) ) {
 	// Do not initialize more than once.
 	return 1;
 }
 
-define( 'DATATYPES_VERSION', '1.1.0' );
-
-/**
- * @deprecated
- */
-define( 'DataTypes_VERSION', DATATYPES_VERSION );
+define( 'DataTypes_VERSION', '1.1.0' );
 
 if ( defined( 'MEDIAWIKI' ) ) {
 	include __DIR__ . '/DataTypes.mw.php';

--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ for the [Wikidata project](https://wikidata.org/).
 ## Release notes
 
 ### 1.1.0 (dev)
-* Renamed `DataTypes_VERSION` constant to `DATATYPES_VERSION`, leaving a deprecated alias.
 * Updated internationalizations.
+* Updated to use the ESLint and Wikibase code sniffers.
 
 ### 1.0.0 (2016-12-29)
 * `DataType` and `DataTypeFactory` do not accept empty strings any more.

--- a/build/travis/script.sh
+++ b/build/travis/script.sh
@@ -10,5 +10,5 @@ cd -
 
 fi
 
-composer test
 ./node_modules/.bin/eslint .
+exit $?

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -2,5 +2,9 @@
 <ruleset name="DataValuesDataTypes">
 	<rule ref="./vendor/wikibase/wikibase-codesniffer/Wikibase" />
 
+	<rule ref="Generic.NamingConventions.UpperCaseConstantName">
+		<exclude-pattern>DataTypes\.php</exclude-pattern>
+	</rule>
+
 	<file>.</file>
 </ruleset>


### PR DESCRIPTION
* I'm moving the `composer test` call out of the shell script. I actually confirmed Travis properly reports errors now by uploading a broken patch first, and then force-push the fixed version you see now.
* I'm purposely reverting the breaking change to the constant that was made in #69. Just renaming this constant is of no value. It should either be removed or stay untouched.