### PR TITLE
Remove MediaWiki wgExtensionCredits registration

### DIFF
--- a/DataTypes.mw.php
+++ b/DataTypes.mw.php
@@ -7,31 +7,15 @@
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 
-namespace DataTypes;
-
 if ( !defined( 'MEDIAWIKI' ) ) {
 	die( 'Not an entry point.' );
 }
-
-$GLOBALS['wgExtensionCredits']['datavalues'][] = [
-	'path' => __DIR__,
-	'name' => 'DataTypes',
-	'version' => DataTypes_VERSION,
-	'author' => [
-		'The Wikidata team',
-	],
-	'url' => 'https://github.com/wmde/DataTypes',
-	'descriptionmsg' => 'datatypes-desc',
-	'license-name' => 'GPL-2.0+'
-];
 
 $GLOBALS['wgMessagesDirs']['DataTypes'] = __DIR__ . '/i18n';
 
 $GLOBALS['wgHooks']['UnitTestsList'][] = function( array &$paths ) {
 	$paths[] = __DIR__ . '/tests/Modules/';
 	$paths[] = __DIR__ . '/tests/Phpunit/';
-
-	return true;
 };
 
 // Resource Loader module registration

--- a/DataTypes.php
+++ b/DataTypes.php
@@ -7,15 +7,6 @@
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 
-namespace DataTypes;
-
-if ( defined( 'DataTypes_VERSION' ) ) {
-	// Do not initialize more than once.
-	return 1;
-}
-
-define( 'DataTypes_VERSION', '1.1.0' );
-
 if ( defined( 'MEDIAWIKI' ) ) {
-	include __DIR__ . '/DataTypes.mw.php';
+	require_once __DIR__ . '/DataTypes.mw.php';
 }

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
 	"name": "data-values/data-types",
 	"type": "library",
-	"description": "PHP library defining the DataTypes\\DataType class of which instances represent a type of value, such as \"positive integer\" or \"percentage\".",
+	"description": "Collection of data type definitions",
 	"keywords": [
 		"datavalues",
 		"datatypes"

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -4,7 +4,6 @@
             "Jeroen De Dauw"
         ]
     },
-    "datatypes-desc": "Collection of data type definitions",
     "datatypes-type-string": "String",
     "datatypes-type-quantity": "Quantity",
     "datatypes-type-monolingualtext": "Monolingual text",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -6,7 +6,6 @@
 			"Umherirrender"
 		]
 	},
-	"datatypes-desc": "{{desc|name=Data Types|url=https://www.mediawiki.org/wiki/Extension:DataTypes}}",
 	"datatypes-type-string": "The name of a data type.\n{{Identical|String}}",
 	"datatypes-type-quantity": "The name of a data type for quantities (proper name, capitalised in English; first letter capitalised anyway in this message and relatives).\n{{Identical|Quantity}}",
 	"datatypes-type-monolingualtext": "The name of a data type.\n{{Identical|Monolingual text}}",


### PR DESCRIPTION
This is a breaking change because I'm removing a constant.

The idea is to simplify this component a bit. Everything I'm removing here is related to this component being listed under [[Special:Version]]. We are not doing this any more for pure PHP libraries. The same information is in composer.json, and [[Special:Version]] will list libraries based on that (when the library is pulled in by core).

This patch here is done in preparation for a possible split of this component: non-MediaWiki related PHP code should go to DataModel, MediaWiki-related to the Wikibase/lib folder (or to a new MediaWiki extension), and the remaining JavaScript code most probably to Wikibase/view (or to a new component).